### PR TITLE
Prioritization and truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,36 @@ The modifications allow for:
 
 A collection of steamdeck startup animations, plus a script to randomize your startup on each boot
 
-You can add/remove webms as long as theyre exactly 1840847 bytes to the `/home/deck/homebrew/startup_animations/deck_startup` directory. The service uses the find command to randomly select one from that folder. 
+You can add/remove webms as long as theyre exactly 1840847 bytes to the `/home/deck/homebrew/startup_animations/deck_startup` directory.
+Files not matching the exact size are ignored during the random selection process.
+The service uses the find command to randomly select one from that folder.
+
+If you have files smaller than the exact size in the `deck_startup` folder, run the `truncate_videos.sh` utility script to enlarge them accordingly.
+Additionally, it will warn you if there are any webm files larger than the size - those you'll have to reencode and compress more, or truncate yourself and lose the end of the video.
 
 The script dynamically polls the original files for the file size and uses regex to find/replace the values needed in the file after making backups. You are using this at your own risk and you should try and understand what it does. I will do my best however to make sure it works.
 
 Two systemd services are installed. One runs on device start which rotates the animation with each startup. A second service runs every time you switch to desktop mode so when you log off from desktop mode you get a new animation into game mode. If you know what you're doing you can install one or both services. 
+
+## Prioritizing videos
+
+You may also increase the chances of some videos to be played during boot by optionally adding an optional parameter within the file names. The syntax is quite simple: `<name>.<chance>.webm`, e.g. `better-call-saul.69.webm` or `star-wars-disneyplus.420.webm`.  
+By default each video has a chance of `1` to be selected as boot animation, i.e. the chances are equal and in long term you should not see one specific video significantly more often than others (unless you only have one).
+With a higher chancee number in the file name the chance of the video to be selected rises. The increase is relative to the amount of videos in the folder and their respective chances.
+
+Example:  
+You have 4 videos with the following names:
+- `hello-there.webm`
+- `those_bastards_lied_to_me.1.webm`
+- `dindu.nuffin.2.webm`
+- `seymour waiting for fry.4.webm`
+
+The chances summed up are **8**:
+- **1** for each `hello-there` (by default in this case) and `those_bastards_lied_to_me`,
+- **2**  for `dindu.nuffin` and
+- **4**  for `seymour waiting for fry`.
+
+This means the first two videos have only 12.5% chance to play each, the third 25% and the last one 50%. In the long run they should play in those ratios.
 
 # So far, I've made boot animations from the following consoles:
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The modifications allow for:
 
 A collection of steamdeck startup animations, plus a script to randomize your startup on each boot
 
-You can add/remove webms as long as theyre exactly 1840847 bytes to the `/home/deck/homebrew/startup_animations/deck_startup` directory.
-Files not matching the exact size are ignored during the random selection process.
-The service uses the find command to randomly select one from that folder.
+You can add/remove webms as long as theyre exactly `1840847` bytes to the `/home/deck/homebrew/startup_animations/deck_startup` directory.
+Files not matching the exact size or not ending with `.webm` are ignored during the random selection process.
+The service uses the `find` command to discover the files, which also works recursively, so don't hesitate to organize your videos in more subfolders.
 
 If you have files smaller than the exact size in the `deck_startup` folder, run the `truncate_videos.sh` utility script to enlarge them accordingly.
 Additionally, it will warn you if there are any webm files larger than the size - those you'll have to reencode and compress more, or truncate yourself and lose the end of the video.
@@ -29,9 +29,9 @@ Two systemd services are installed. One runs on device start which rotates the a
 
 ## Prioritizing videos
 
-You may also increase the chances of some videos to be played during boot by optionally adding an optional parameter within the file names. The syntax is quite simple: `<name>.<chance>.webm`, e.g. `better-call-saul.69.webm` or `star-wars-disneyplus.420.webm`.  
+You may also increase the chances of some videos to be played during boot by adding an optional "parameter" within the file names. The syntax is quite simple: `<name>.<chance>.webm`, e.g. `better-call-saul.69.webm` or `star-wars-disneyplus.420.webm`.  
 By default each video has a chance of `1` to be selected as boot animation, i.e. the chances are equal and in long term you should not see one specific video significantly more often than others (unless you only have one).
-With a higher chancee number in the file name the chance of the video to be selected rises. The increase is relative to the amount of videos in the folder and their respective chances.
+With a higher chance number in the file name the chance of the video to be selected rises. The increase is relative to the amount of videos in the folder and their respective chances.
 
 Example:  
 You have 4 videos with the following names:
@@ -42,10 +42,10 @@ You have 4 videos with the following names:
 
 The chances summed up are **8**:
 - **1** for each `hello-there` (by default in this case) and `those_bastards_lied_to_me`,
-- **2**  for `dindu.nuffin` and
-- **4**  for `seymour waiting for fry`.
+- **2** for `dindu.nuffin` and
+- **4** for `seymour waiting for fry`.
 
-This means the first two videos have only 12.5% chance to play each, the third 25% and the last one 50%. In the long run they should play in those ratios.
+This means the first two videos have only a 12.5% chance to play each, the third 25% and the last one 50%. In the long run they should play in those ratios.
 
 # So far, I've made boot animations from the following consoles:
 

--- a/constants
+++ b/constants
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+Color_Off='\033[0m'       # Text Reset
+
+# Regular Colors
+Black='\033[0;30m'        # Black
+Red='\033[0;31m'          # Red
+Green='\033[0;32m'        # Green
+Yellow='\033[0;33m'       # Yellow
+Blue='\033[0;34m'         # Blue
+Purple='\033[0;35m'       # Purple
+Cyan='\033[0;36m'         # Cyan
+White='\033[0;37m'        # White
+
+
+DECK_STARTUP_FILE="/home/deck/.steam/steam/steamui/movies/deck_startup.webm"
+DECK_STARTUP_FILE_SIZE=1840847
+DECK_STARTUP_STOCK_MD5="4ee82f478313cf74010fc22501b40729"
+
+DECK_CSS_FILE="/home/deck/.steam/steam/steamui/css/library.css"
+#previous hashes 22d52af1fc507209fef4cf72a7a234d4
+DECK_CSS_STOCK_MD5="1540f8c3a3944590c5892b0947ce43e6"
+
+DECK_JS_FILE="/home/deck/.steam/steam/steamui/library.js"
+#previous hashes 047a4968a9e81faba14727a498f45429
+DECK_JS_STOCK_MD5="ee49f2778c8af821590ca6899260cccf"

--- a/randomize_deck_startup.sh
+++ b/randomize_deck_startup.sh
@@ -1,16 +1,6 @@
 #!/usr/bin/env bash
 
-Color_Off='\033[0m'       # Text Reset
-
-# Regular Colors
-Black='\033[0;30m'        # Black
-Red='\033[0;31m'          # Red
-Green='\033[0;32m'        # Green
-Yellow='\033[0;33m'       # Yellow
-Blue='\033[0;34m'         # Blue
-Purple='\033[0;35m'       # Purple
-Cyan='\033[0;36m'         # Cyan
-White='\033[0;37m'        # White
+. ./constants
 
 msg() {
   echo -e ":: ${@}$Color_Off"
@@ -19,10 +9,6 @@ msg() {
 msg2() {
   echo -e "$Red!!$Color_Off ${@}$Color_Off"
 }
-
-DECK_STARTUP_FILE="/home/deck/.steam/steam/steamui/movies/deck_startup.webm"
-DECK_STARTUP_FILE_SIZE=1840847
-DECK_STARTUP_STOCK_MD5="4ee82f478313cf74010fc22501b40729"
 
 check_backup() {
   if [[ ! -f "$DECK_STARTUP_FILE.backup" ]]; then
@@ -35,14 +21,6 @@ check_backup() {
     fi
   fi
 }
-
-DECK_CSS_FILE="/home/deck/.steam/steam/steamui/css/library.css"
-#previous hashes 22d52af1fc507209fef4cf72a7a234d4
-DECK_CSS_STOCK_MD5="1540f8c3a3944590c5892b0947ce43e6"
-
-DECK_JS_FILE="/home/deck/.steam/steam/steamui/library.js"
-#previous hashes 047a4968a9e81faba14727a498f45429
-DECK_JS_STOCK_MD5="ee49f2778c8af821590ca6899260cccf"
 
 check_backup_js_css() {
   if [[ ! -f "$DECK_CSS_FILE.backup" ]]; then

--- a/randomize_deck_startup.sh
+++ b/randomize_deck_startup.sh
@@ -71,11 +71,22 @@ check_backup_js_css() {
 }
 
 list_animations() {
-  find ./deck_startup/ -type f -size "${DECK_STARTUP_FILE_SIZE}c" -iname '*.webm' -print0
+  find ./deck_startup/ -type f -size "${DECK_STARTUP_FILE_SIZE}c" -iname '*.webm'
 }
 
 random_animation() {
-  list_animations | shuf -z -n 1
+  # for each listed file
+  list_animations | while IFS= read -r file; do
+    repeat=1
+    # check if it has a number at the end, e.g. some-animation.5.webm
+    if [[ $file =~ .*\.([0-9]+)\.[A-Za-z0-9]+$ ]]; then
+      repeat="${BASH_REMATCH[1]}"
+    fi
+    # and repeat the file said number of times, increasing its chance
+    yes "$file" | head -n $repeat
+  done | shuf -n 1
+  # in the end, shuffle the list of files (including repetitions) and select first
+
   # mapfile -d $'\0' animations < <(list_animations)
   # #add SEED based on pid with $$
   # RANDOM=$$

--- a/truncate_videos.sh
+++ b/truncate_videos.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DECK_STARTUP_FILE_SIZE=1840847
+. ./constants
 
 SMALLER_FILES="$(find ./deck_startup/ -type f -iname "*.webm" -size "-${DECK_STARTUP_FILE_SIZE}c")"
 if [ "$(echo "$SMALLER_FILES" | wc -l)" -gt 0 ] && [ "$SMALLER_FILES" != "" ]; then

--- a/truncate_videos.sh
+++ b/truncate_videos.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+DECK_STARTUP_FILE_SIZE=1840847
+
+SMALLER_FILES="$(find ./deck_startup/ -type f -iname "*.webm" -size "-${DECK_STARTUP_FILE_SIZE}c")"
+if [ "$(echo "$SMALLER_FILES" | wc -l)" -gt 0 ] && [ "$SMALLER_FILES" != "" ]; then
+    echo "Truncating files smaller than $DECK_STARTUP_FILE_SIZE B." >&2
+    while read -r file; do
+        echo "  $file"
+        truncate -s "$DECK_STARTUP_FILE_SIZE" "$file"
+    done <<< "$SMALLER_FILES"
+else
+    echo "No files to truncate." >&2
+fi
+
+LARGER_FILES="$(find ./deck_startup/ -type f -iname "*.webm" -size "+${DECK_STARTUP_FILE_SIZE}c")"
+if [ "$(echo "$LARGER_FILES" | wc -l)" -gt 0 ] && [ "$LARGER_FILES" != "" ]; then
+    echo -e "\nWARNING: Following files are too large for the startup video:"
+    while read -r file; do
+        echo "  $file"
+    done <<< "$LARGER_FILES"
+fi >&2


### PR DESCRIPTION
Hello again, we met on Reddit the other day.
While I said I'd try to implement checking the Steam API for currently occurring events to select a specific The Lord Gaben video, there was something else bugging me more than anything. I like to play certain animations more often than others, but still want those less favorite to appear from time to time. Silly, I know, since you don't reboot your deck that often. But still, there is demand (from me) and there is supply (also me).

Anyway, I forked your project and mildly edited the logic in selecting a random video from the folder. Now it does support the prioritization syntax, while still being backwards compatible with no syntax at all. It's only going to be awkward if someone names their videos something like `i.love.you.3000.webm` (and those people probably deserve it).

A smaller part is a small script to automatically truncate smaller videos to fit the size. I find that useful, you just download the files, move them over to the folder, run the script, voilà. Well, except if the videos are larger, automatically compressing while reeconding the videos is a feature more advanced than just 22 shell lines.

Please take a look at the README.